### PR TITLE
set var type of master in LQSolve

### DIFF
--- a/src/LQSolver.jl
+++ b/src/LQSolver.jl
@@ -6,7 +6,7 @@ mutable struct LQSolver{M <: AbstractLinearQuadraticModel, S <: AbstractMathProg
         lqmodel = LinearQuadraticModel(optimsolver)
         solver = new{typeof(lqmodel),typeof(optimsolver)}(lqmodel,optimsolver)
         loadproblem!(solver.lqmodel,loadLP(model)...)
-
+        setvartype!(lqmodel, model.colCat)
         return solver
     end
 end


### PR DESCRIPTION
Hello Martin! 
I was checking the library, and I've loved it. However, I noticed that the master problem gets relaxed on LQSolve (when you create the LinearQuadraticModel), despite having integer variables in the JuMP model. If I'm correct, allowing for a MIP master doesn't affect the algorithm in any way. So I added one line to pass the category of the variables from the JuMP model to the MathProgBase LinearQuadraticModel. This generalizes a little bit the problems suited for the library.

Just run the tests (which are all continuous, so it's the same as before), and appears to not break anything. And with some MIP-master-instances of my own, it appears to work fine as well.

P.S.: if you like this and merge, maybe the name of the function loadLP would be a little weird, and LoadProblem or something more generic would be better.